### PR TITLE
add purs-tidy 0.7.0 to nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,5 +13,6 @@ pkgs.stdenv.mkDerivation {
     pursPkgs.purs
     pursPkgs.spago
     pursPkgs.zephyr
+    pursPkgs.purs-tidy
   ];
 }


### PR DESCRIPTION
I saw that the purs-tidy was updated to 0.7.0, so added it to the shell.nix and everything has installed and works